### PR TITLE
[Close #5] Add linear interpolation and wait option to SetObjectRequest with benchmarking support

### DIFF
--- a/components/viewer/src/camera.rs
+++ b/components/viewer/src/camera.rs
@@ -4,6 +4,7 @@ use bevy::{
 };
 use std::{f32::consts::FRAC_PI_2, ops::Range};
 
+/// Bevy plugin that sets up the 3D camera and its control systems.
 pub struct CameraPlugin;
 
 impl Plugin for CameraPlugin {
@@ -51,6 +52,7 @@ impl Default for CameraSettings {
     }
 }
 
+/// Spawns and configures the main 3D camera entity.
 fn setup_camera(mut commands: Commands) {
     commands.spawn((
         Name::new("Main Camera"),
@@ -59,7 +61,7 @@ fn setup_camera(mut commands: Commands) {
     ));
 }
 
-/// 回転と距離だけを担当。注視点は `CameraTarget` から取得。
+/// Rotates the camera around the target based on mouse drag input.
 fn orbit(
     mut camera: Single<&mut Transform, With<Camera>>,
     camera_settings: Res<CameraSettings>,
@@ -90,7 +92,7 @@ fn orbit(
     camera.translation = target.0 - camera.forward() * camera_settings.orbit_distance;
 }
 
-/// マウスホイールでズーム
+/// Zooms the camera in and out using the mouse wheel.
 fn handle_zoom(mut settings: ResMut<CameraSettings>, mut wheels: EventReader<MouseWheel>) {
     let scroll: f32 = wheels.read().map(|e| e.y).sum();
     if scroll != 0.0 {
@@ -99,7 +101,7 @@ fn handle_zoom(mut settings: ResMut<CameraSettings>, mut wheels: EventReader<Mou
     }
 }
 
-/// キーボードで注視点を平行移動
+/// Moves the camera target using WASD keyboard input.
 fn handle_movement(
     mut target: ResMut<CameraTarget>,
     camera_settings: Res<CameraSettings>,
@@ -127,7 +129,7 @@ fn handle_movement(
     }
 }
 
-/// 中ボタンドラッグで平行移動（パン）
+/// Pans the camera target when dragging with the middle mouse button.
 fn handle_drag(
     mut target: ResMut<CameraTarget>,
     camera: Single<&mut Transform, With<Camera>>,

--- a/components/viewer/src/camera.rs
+++ b/components/viewer/src/camera.rs
@@ -8,6 +8,7 @@ use std::{f32::consts::FRAC_PI_2, ops::Range};
 pub struct CameraPlugin;
 
 impl Plugin for CameraPlugin {
+    /// Inserts camera resources and registers camera control systems.
     fn build(&self, app: &mut App) {
         app.init_resource::<CameraSettings>()
             .init_resource::<CameraTarget>()

--- a/components/viewer/src/input.rs
+++ b/components/viewer/src/input.rs
@@ -1,6 +1,7 @@
 use crate::camera::CameraSettings;
 use bevy::prelude::*;
 
+/// Bevy plugin that registers input systems for camera inversion toggles.
 pub struct InputPlugin;
 
 impl Plugin for InputPlugin {
@@ -19,6 +20,7 @@ pub enum ToggleAction {
     InvertYaw,
 }
 
+/// Toggles camera pitch/yaw inversion on key press and updates UI text.
 pub fn toggle_input_system(
     mut camera_settings: ResMut<CameraSettings>,
     mut query: Query<(&mut Text, &ToggleButton)>,

--- a/components/viewer/src/input.rs
+++ b/components/viewer/src/input.rs
@@ -5,6 +5,7 @@ use bevy::prelude::*;
 pub struct InputPlugin;
 
 impl Plugin for InputPlugin {
+    /// Registers the system for toggling camera inversion based on input.
     fn build(&self, app: &mut App) {
         app.add_systems(Update, toggle_input_system);
     }

--- a/components/viewer/src/manage_objects/global.rs
+++ b/components/viewer/src/manage_objects/global.rs
@@ -12,6 +12,7 @@ pub struct InternalRequestList {
 }
 
 impl InternalRequestList {
+    /// Creates a new internal request list backed by a thread-safe vector.
     pub fn new() -> Self {
         InternalRequestList {
             list: ThreadSafeVecRw::new(),
@@ -22,6 +23,7 @@ impl InternalRequestList {
 impl Deref for InternalRequestList {
     type Target = ThreadSafeVecRw<super::request::InternalRequest>;
 
+    /// Returns a reference to the underlying thread-safe request vector.
     fn deref(&self) -> &Self::Target {
         &self.list
     }

--- a/components/viewer/src/manage_objects/mod.rs
+++ b/components/viewer/src/manage_objects/mod.rs
@@ -3,9 +3,11 @@ pub mod request;
 
 use bevy::prelude::*;
 
+/// Bevy plugin that sets up the infrastructure for processing object spawn and movement requests.
 pub struct ManageObjectsPlugin;
 
 impl Plugin for ManageObjectsPlugin {
+    /// Inserts the InternalRequestCursor resource and adds the InternalRequestPlugin.
     fn build(&self, app: &mut App) {
         app.insert_resource(request::InternalRequestCursor::new())
             .add_plugins(request::InternalRequestPlugin);

--- a/components/viewer/src/manage_objects/request.rs
+++ b/components/viewer/src/manage_objects/request.rs
@@ -7,12 +7,14 @@ use super::global::INTERNAL_REQUEST_LIST;
 pub struct InternalRequestPlugin;
 
 impl Plugin for InternalRequestPlugin {
+    /// Registers the object request plugin and the request-processing system.
     fn build(&self, app: &mut App) {
         app.add_plugins(object::ObjectRequestPlugin)
             .add_systems(Update, process_requests);
     }
 }
 
+/// Processes queued internal requests and emits corresponding spawn/position events.
 pub fn process_requests(
     mut request_cursor: ResMut<InternalRequestCursor>,
     mut spawn_request_event: EventWriter<object::SpawnObjectRequest>,

--- a/components/viewer/src/manage_objects/request/object.rs
+++ b/components/viewer/src/manage_objects/request/object.rs
@@ -1,5 +1,5 @@
-use std::fmt::Display;
 use bevy::prelude::{Time, *};
+use std::fmt::Display;
 use uuid::Uuid;
 
 // 線形補間速度を外部から指定する Resource
@@ -8,13 +8,19 @@ pub struct SmoothMovementSettings {
     pub speed: f32,
 }
 
+impl Default for SmoothMovementSettings {
+    fn default() -> Self {
+        Self { speed: 10.0 }
+    }
+}
+
 pub struct ObjectRequestPlugin;
 
 impl Plugin for ObjectRequestPlugin {
     fn build(&self, app: &mut App) {
         app
             // 補間速度の初期値を 5.0 に設定
-            .insert_resource(SmoothMovementSettings { speed: 5.0 })
+            .init_resource::<SmoothMovementSettings>()
             .add_event::<SetObjectPositionRequest>()
             .add_systems(Update, SetObjectPositionRequest::event_handler)
             .add_event::<SpawnObjectRequest>()

--- a/components/viewer/src/manage_objects/request/object.rs
+++ b/components/viewer/src/manage_objects/request/object.rs
@@ -1,5 +1,8 @@
 use std::fmt::Display;
 
+// ■ 追加：滑らか移動を有効化するフラグ（定数で切り替え）
+const ENABLE_SMOOTH_MOVEMENT: bool = true;
+
 use bevy::prelude::{Time, *};
 use uuid::Uuid;
 
@@ -39,9 +42,14 @@ impl SetObjectPositionRequest {
                         "Setting position of object {} to {:?}",
                         object_id, event.position
                     );
-                    // 線形補間で滑らかに移動
-                    let alpha = (time.delta_seconds() * 5.0).clamp(0.0, 1.0);
-                    transform.translation = transform.translation.lerp(event.position, alpha);
+                    if ENABLE_SMOOTH_MOVEMENT {
+                        // 線形補間で滑らかに移動
+                        let alpha = (time.delta_seconds() * 5.0).clamp(0.0, 1.0);
+                        transform.translation = transform.translation.lerp(event.position, alpha);
+                    } else {
+                        // 非スムーズモードでは直接位置設定
+                        transform.translation = event.position;
+                    }
                 }
             }
         }

--- a/components/viewer/src/manage_objects/request/object.rs
+++ b/components/viewer/src/manage_objects/request/object.rs
@@ -2,15 +2,21 @@ use bevy::prelude::*;
 use std::fmt::Display;
 use uuid::Uuid;
 
-// 線形補間速度を外部から指定する Resource
+// 線形補完速度と有効無効を外部から指定する Resource
 #[derive(Resource)]
 pub struct SmoothMovementSettings {
+    /// 補完の速さ（大きいほど速くターゲットに近づく）
     pub speed: f32,
+    /// 補完を有効にするかどうか
+    pub enabled: bool,
 }
 
 impl Default for SmoothMovementSettings {
     fn default() -> Self {
-        Self { speed: 10.0 }
+        Self {
+            speed: 10.0,
+            enabled: true,
+        }
     }
 }
 
@@ -23,6 +29,7 @@ pub struct ObjectRequestPlugin;
 impl Plugin for ObjectRequestPlugin {
     fn build(&self, app: &mut App) {
         app
+            // Resource を初期化（Default を利用）
             .init_resource::<SmoothMovementSettings>()
             .add_event::<SpawnObjectRequest>()
             .add_systems(Update, SpawnObjectRequest::event_handler)
@@ -114,15 +121,22 @@ impl SpawnObjectRequest {
     }
 }
 
-// 滑らか移動用システム：毎フレーム、Transform を TargetPosition に向かって線形補間する
+// 滑らか移動用システム：毎フレーム、Transform を TargetPosition に向かって線形補完する
 fn smooth_movement_system(
     time: Res<Time>,
     settings: Res<SmoothMovementSettings>,
     mut query: Query<(&mut Transform, &TargetPosition)>,
 ) {
-    let alpha = (time.delta_seconds() * settings.speed).clamp(0.0, 1.0);
+    // 補完率を計算
+    let alpha = (time.delta_secs() * settings.speed).clamp(0.0, 1.0);
     for (mut transform, target) in query.iter_mut() {
-        transform.translation = transform.translation.lerp(target.0, alpha);
+        if settings.enabled {
+            // 補完あり
+            transform.translation = transform.translation.lerp(target.0, alpha);
+        } else {
+            // 補完なし
+            transform.translation = target.0;
+        }
     }
 }
 

--- a/components/viewer/src/manage_objects/request/object.rs
+++ b/components/viewer/src/manage_objects/request/object.rs
@@ -44,7 +44,7 @@ impl SetObjectPositionRequest {
                     );
                     if ENABLE_SMOOTH_MOVEMENT {
                         // 線形補間で滑らかに移動
-                        let alpha = (time.delta_seconds() * 5.0).clamp(0.0, 1.0);
+                        let alpha = (time.delta_secs() * 5.0).clamp(0.0, 1.0);
                         transform.translation = transform.translation.lerp(event.position, alpha);
                     } else {
                         // 非スムーズモードでは直接位置設定

--- a/components/viewer/src/manage_objects/request/object.rs
+++ b/components/viewer/src/manage_objects/request/object.rs
@@ -27,6 +27,7 @@ pub struct TargetPosition(pub Vec3);
 pub struct ObjectRequestPlugin;
 
 impl Plugin for ObjectRequestPlugin {
+    /// Initializes smooth movement settings and registers object request systems.
     fn build(&self, app: &mut App) {
         app
             // Resource を初期化（Default を利用）
@@ -52,6 +53,7 @@ pub struct SetObjectPositionRequest {
 }
 
 impl SetObjectPositionRequest {
+    /// Handles incoming position events by updating entities’ target positions.
     pub fn event_handler(
         mut event_reader: EventReader<Self>,
         mut query: Query<(&ObjectId, &mut TargetPosition)>,
@@ -78,6 +80,7 @@ pub struct SpawnObjectRequest {
 }
 
 impl SpawnObjectRequest {
+    /// Handles spawn events by creating new entities with given properties.
     pub fn event_handler(
         mut event_reader: EventReader<Self>,
         mut commands: Commands,
@@ -121,7 +124,7 @@ impl SpawnObjectRequest {
     }
 }
 
-// 滑らか移動用システム：毎フレーム、Transform を TargetPosition に向かって線形補完する
+/// Smoothly interpolates each entity’s transform toward its target position.
 fn smooth_movement_system(
     time: Res<Time>,
     settings: Res<SmoothMovementSettings>,

--- a/components/viewer/src/manage_objects/request/object.rs
+++ b/components/viewer/src/manage_objects/request/object.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use bevy::prelude::*;
+use bevy::prelude::{Time, *};
 use uuid::Uuid;
 
 pub struct ObjectRequestPlugin;
@@ -30,6 +30,7 @@ impl SetObjectPositionRequest {
     pub fn event_handler(
         mut event_reader: EventReader<Self>,
         mut query: Query<(&ObjectId, &mut Transform)>,
+        time: Res<Time>,
     ) {
         for event in event_reader.read() {
             for (object_id, mut transform) in query.iter_mut() {
@@ -38,7 +39,9 @@ impl SetObjectPositionRequest {
                         "Setting position of object {} to {:?}",
                         object_id, event.position
                     );
-                    transform.translation = event.position;
+                    // 線形補間で滑らかに移動
+                    let alpha = (time.delta_seconds() * 5.0).clamp(0.0, 1.0);
+                    transform.translation = transform.translation.lerp(event.position, alpha);
                 }
             }
         }

--- a/components/viewer/src/manage_objects/request/object.rs
+++ b/components/viewer/src/manage_objects/request/object.rs
@@ -1,8 +1,4 @@
 use std::fmt::Display;
-
-// ■ 追加：滑らか移動を有効化するフラグ（定数で切り替え）
-const ENABLE_SMOOTH_MOVEMENT: bool = true;
-
 use bevy::prelude::{Time, *};
 use uuid::Uuid;
 
@@ -42,14 +38,9 @@ impl SetObjectPositionRequest {
                         "Setting position of object {} to {:?}",
                         object_id, event.position
                     );
-                    if ENABLE_SMOOTH_MOVEMENT {
-                        // 線形補間で滑らかに移動
-                        let alpha = (time.delta_secs() * 5.0).clamp(0.0, 1.0);
-                        transform.translation = transform.translation.lerp(event.position, alpha);
-                    } else {
-                        // 非スムーズモードでは直接位置設定
-                        transform.translation = event.position;
-                    }
+                    // 線形補間で滑らかに移動
+                    let alpha = (time.delta_secs() * 5.0).clamp(0.0, 1.0);
+                    transform.translation = transform.translation.lerp(event.position, alpha);
                 }
             }
         }

--- a/components/viewer/src/rpc/mod.rs
+++ b/components/viewer/src/rpc/mod.rs
@@ -4,9 +4,11 @@ mod proto;
 mod serve;
 mod service;
 
+/// Bevy plugin that initializes and runs the gRPC server for remote object management.
 pub struct RpcPlugin;
 
 impl Plugin for RpcPlugin {
+    /// Registers the GrpcServer resource and schedules the system to spawn the gRPC server.
     fn build(&self, app: &mut App) {
         app.insert_resource(GrpcServer::default())
             .add_systems(Startup, spawn_grpc_request_system);

--- a/components/viewer/src/rpc/serve.rs
+++ b/components/viewer/src/rpc/serve.rs
@@ -9,6 +9,7 @@ use tonic::transport::Server;
 
 use super::service::ManageObjectServiceImpl;
 
+/// Starts the gRPC server on the specified socket address.
 pub async fn serve_grpc(addr: std::net::SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
     let manage_object_service = ManageObjectServiceImpl::default();
 
@@ -32,6 +33,7 @@ impl Default for GrpcServer {
     }
 }
 
+/// Spawns a thread running the Tokio runtime to serve the gRPC server.
 pub fn spawn_grpc_request_system(grpc_server: Res<GrpcServer>) {
     let addr = grpc_server.addr;
 

--- a/components/viewer/src/rpc/service.rs
+++ b/components/viewer/src/rpc/service.rs
@@ -167,6 +167,7 @@ pub enum SetObjectPositionError {
     InvalidPosition,
 }
 
+/// Converts a gRPC SetObjectPositionRequest into an internal request, validating fields.
 pub fn set_position_request_to_internal_request(
     set_position_request: SetObjectPositionRequest,
 ) -> std::result::Result<request::object::SetObjectPositionRequest, SetObjectPositionError> {
@@ -210,6 +211,7 @@ pub enum SpawnObjectError {
     InvalidObjectProperties,
 }
 
+/// Converts a gRPC SpawnObjectRequest into an internal request, validating fields and assigning a UUID.
 pub fn spawn_object_request_to_internal_request(
     spawn_object_request: SpawnObjectRequest,
 ) -> std::result::Result<request::object::SpawnObjectRequest, SpawnObjectError> {
@@ -257,6 +259,7 @@ pub fn spawn_object_request_to_internal_request(
     Ok(spawn_request)
 }
 
+/// Transforms a gRPC ObjectColor into a Bevy Color, validating values and enum variants.
 pub fn normalize_object_color(object_color: ObjectColor) -> anyhow::Result<bevy::color::Color> {
     let ObjectColor { color } = object_color;
 

--- a/components/viewer/src/scene.rs
+++ b/components/viewer/src/scene.rs
@@ -11,6 +11,7 @@ impl Plugin for ScenePlugin {
     }
 }
 
+/// Spawns the directional light used in the scene.
 pub fn setup(mut commands: Commands) {
     commands.spawn((
         Name::new("Light"),
@@ -25,6 +26,7 @@ pub fn setup(mut commands: Commands) {
     ));
 }
 
+/// Adds on-screen text that describes available camera controls.
 pub fn instructions(mut commands: Commands) {
     commands.spawn((
         Name::new("Instructions"),
@@ -45,6 +47,7 @@ pub fn instructions(mut commands: Commands) {
     ));
 }
 
+/// Constructs the UI panel with toggle buttons for pitch/yaw inversion.
 pub fn setup_ui(mut commands: Commands) {
     // UIの親ノード
     commands

--- a/components/viewer/src/scene.rs
+++ b/components/viewer/src/scene.rs
@@ -4,6 +4,7 @@ use bevy::prelude::*;
 pub struct ScenePlugin;
 
 impl Plugin for ScenePlugin {
+    /// Registers systems for scene setup, instruction text, and UI panel.
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup)
             .add_systems(Startup, instructions)

--- a/components/viewer/src/types/mod.rs
+++ b/components/viewer/src/types/mod.rs
@@ -6,17 +6,20 @@ pub struct ThreadSafeVecRw<T> {
 }
 
 impl<T> ThreadSafeVecRw<T> {
+    /// Creates an empty, thread-safe vector.
     pub fn new() -> Self {
         ThreadSafeVecRw {
             inner: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
+    /// Appends a value to the inner vector with write-lock protection.
     pub fn push(&self, value: T) {
         let mut vec = self.inner.write().unwrap();
         vec.push(value);
     }
 
+    /// Retrieves and clones the element at the given index, if any.
     pub fn get(&self, index: usize) -> Option<T>
     where
         T: Clone,
@@ -25,11 +28,13 @@ impl<T> ThreadSafeVecRw<T> {
         vec.get(index).cloned()
     }
 
+    /// Returns the current number of elements in the vector.
     pub fn len(&self) -> usize {
         let vec = self.inner.read().unwrap();
         vec.len()
     }
 
+    /// Returns a read guard for the internal vector or an error if poisoned.
     pub fn get_reader(
         &self,
     ) -> Result<RwLockReadGuard<Vec<T>>, std::sync::PoisonError<RwLockReadGuard<Vec<T>>>> {

--- a/examples/benchmark_01/main.go
+++ b/examples/benchmark_01/main.go
@@ -37,12 +37,19 @@ func (d *DurationFlag) Set(s string) error {
 }
 func (d *DurationFlag) IsBoolFlag() bool { return true }
 
-var wait = &DurationFlag{Default: 500 * time.Millisecond, Duration: 500 * time.Millisecond}
+// SpawnObjectSequence 用の待機時間フラグ
+var spawnWait = &DurationFlag{Default: 500 * time.Millisecond, Duration: 500 * time.Millisecond}
+// SetObjectPositionSequence 用の待機時間フラグ
+var setWait   = &DurationFlag{Default: 500 * time.Millisecond, Duration: 500 * time.Millisecond}
 
 func init() {
-	flag.Var(wait, "wait", fmt.Sprintf(
-		"delay between RPC calls (default = %v, or specify -wait=<duration>)",
-		wait.Default,
+	flag.Var(spawnWait, "spawn-wait", fmt.Sprintf(
+		"delay before SpawnObjectSequence RPC (default = %v or -spawn-wait=<duration>)",
+		spawnWait.Default,
+	))
+	flag.Var(setWait,   "set-wait", fmt.Sprintf(
+		"delay before SetObjectPositionSequence RPC (default = %v or -set-wait=<duration>)",
+		setWait.Default,
 	))
 }
 
@@ -70,7 +77,7 @@ func main() {
 
 	// Send 100 requests of SpawnObjectSequenceRequest thath contains 100 SpawnObjectRequest (Spawing 10000 objects)
 	for i := range 100 {
-		time.Sleep(wait.Duration)
+		time.Sleep(spawnWait.Duration)
 		resp, err := client.SpawnObjectSequence(ctx, reqs)
 		if err != nil {
 			log.Fatalf("RPC failed: %v", err)
@@ -88,7 +95,7 @@ func main() {
 
 		// Send 100*100 requests of `SetObjectPositionRequest` that contains 100 `SetObjectPositionRequest` (Moving 10000 objects)
 		for i := range 100 {
-			time.Sleep(wait.Duration)
+			time.Sleep(setWait.Duration)
 			var reqs2 *viewer.SetObjectPositionSequenceRequest = &viewer.SetObjectPositionSequenceRequest{
 				Requests: make([]*viewer.SetObjectPositionRequest, 100),
 			}

--- a/examples/benchmark_01/main.go
+++ b/examples/benchmark_01/main.go
@@ -2,15 +2,20 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"math/rand/v2"
+	"time"
 
 	viewer "github.com/ALifeComponent/human-interface-engine/gen/go/viewer/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+var wait = flag.Duration("wait", 500*time.Millisecond, "delay between RPC calls")
+
 func main() {
+	flag.Parse()
 	conn, err := grpc.NewClient("localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("failed to connect: %v", err)
@@ -33,6 +38,7 @@ func main() {
 
 	// Send 100 requests of SpawnObjectSequenceRequest thath contains 100 SpawnObjectRequest (Spawing 10000 objects)
 	for i := range 100 {
+		time.Sleep(*wait)
 		resp, err := client.SpawnObjectSequence(ctx, reqs)
 		if err != nil {
 			log.Fatalf("RPC failed: %v", err)
@@ -50,6 +56,7 @@ func main() {
 
 		// Send 100*100 requests of `SetObjectPositionRequest` that contains 100 `SetObjectPositionRequest` (Moving 10000 objects)
 		for i := range 100 {
+			time.Sleep(*wait)
 			var reqs2 *viewer.SetObjectPositionSequenceRequest = &viewer.SetObjectPositionSequenceRequest{
 				Requests: make([]*viewer.SetObjectPositionRequest, 100),
 			}

--- a/examples/benchmark_01/main.go
+++ b/examples/benchmark_01/main.go
@@ -50,7 +50,7 @@ func init() {
 		spawnWait.Default,
 	))
 	flag.Var(setPositionWait, "set-position-wait", fmt.Sprintf(
-		"delay before SetObjectPositionSequence RPC (default = %v or -set-wait=<duration>)",
+		"delay before SetObjectPositionSequence RPC (default = %v or -set-position-wait=<duration>)",
 		setPositionWait.Default,
 	))
 }

--- a/examples/benchmark_01/main.go
+++ b/examples/benchmark_01/main.go
@@ -14,8 +14,9 @@ import (
 )
 
 // ■ カスタム Duration フラグ
-//    -wait        → デフォルト値を使う (500ms)
-//     -wait=200ms → 200ms を使う
+//
+//	-wait        → デフォルト値を使う (500ms)
+//	 -wait=200ms → 200ms を使う
 type DurationFlag struct {
 	Duration time.Duration
 	Default  time.Duration
@@ -39,17 +40,18 @@ func (d *DurationFlag) IsBoolFlag() bool { return true }
 
 // SpawnObjectSequence 用の待機時間フラグ
 var spawnWait = &DurationFlag{Default: 500 * time.Millisecond, Duration: 500 * time.Millisecond}
+
 // SetObjectPositionSequence 用の待機時間フラグ
-var setWait   = &DurationFlag{Default: 500 * time.Millisecond, Duration: 500 * time.Millisecond}
+var setPositionWait = &DurationFlag{Default: 500 * time.Millisecond, Duration: 500 * time.Millisecond}
 
 func init() {
 	flag.Var(spawnWait, "spawn-wait", fmt.Sprintf(
 		"delay before SpawnObjectSequence RPC (default = %v or -spawn-wait=<duration>)",
 		spawnWait.Default,
 	))
-	flag.Var(setWait,   "set-wait", fmt.Sprintf(
+	flag.Var(setPositionWait, "set-position-wait", fmt.Sprintf(
 		"delay before SetObjectPositionSequence RPC (default = %v or -set-wait=<duration>)",
-		setWait.Default,
+		setPositionWait.Default,
 	))
 }
 
@@ -95,7 +97,7 @@ func main() {
 
 		// Send 100*100 requests of `SetObjectPositionRequest` that contains 100 `SetObjectPositionRequest` (Moving 10000 objects)
 		for i := range 100 {
-			time.Sleep(setWait.Duration)
+			time.Sleep(setPositionWait.Duration)
 			var reqs2 *viewer.SetObjectPositionSequenceRequest = &viewer.SetObjectPositionSequenceRequest{
 				Requests: make([]*viewer.SetObjectPositionRequest, 100),
 			}


### PR DESCRIPTION
## Changes

- 線形補完の追加
- リクエストのwaitを追加したbenchmarkの実装
- Resourceで線形補完の有効無効、および速度の設定
- Doc コメントの追加

## Benchmark and testing

10msごとにランダムの位置への設定をリクエストした。

`go run ./examples/benchmark_01/main.go -set-position-wait=10ms -spawn-wait=0ms`

https://github.com/user-attachments/assets/7ba27323-3272-455e-b930-33671604e028